### PR TITLE
add timestamp sorting to get all texts and fixed bug with text parsing

### DIFF
--- a/src/main/java/com/masterPi/data/impl/QuickSpringRepository.java
+++ b/src/main/java/com/masterPi/data/impl/QuickSpringRepository.java
@@ -26,7 +26,7 @@ public class QuickSpringRepository implements QuickRepository {
     }
 
     public List<Text> getAllText(){
-        return textJPA.findAll();
+        return textJPA.findAllByOrderByTimeStampDesc();
     }
 
     public Text createText(Text text){

--- a/src/main/java/com/masterPi/data/impl/TextJPA.java
+++ b/src/main/java/com/masterPi/data/impl/TextJPA.java
@@ -2,6 +2,9 @@ package com.masterPi.data.impl;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TextJPA extends JpaRepository<Text, Long>{
     Text findFirstBySelectedEquals(Boolean Selected);
+    List<Text> findAllByOrderByTimeStampDesc();
 }

--- a/src/main/java/com/masterPi/services/TextServices.java
+++ b/src/main/java/com/masterPi/services/TextServices.java
@@ -125,7 +125,7 @@ public class TextServices {
         Text text=getCurrentSelectedText();
 
         //check we are not at end of content
-        if(text.getIndex()+Integer.parseInt(env.getProperty("parseSize"))<=text.getText().length()){
+        if(text.getIndex()+Integer.parseInt(env.getProperty("parseSize"))<text.getText().length()){
             text.setIndex(text.getIndex()+Integer.parseInt(env.getProperty("parseSize")));
         }
 


### PR DESCRIPTION
improved get all text endpoint will now sort by timestamp newest -> oldest
fixed bug with text parsing